### PR TITLE
Add Docker setup and init script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Git files
+.git
+.gitignore
+.github
+
+# Build artifacts
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+twitch-miner
+build/
+
+# Test and coverage files
+*.test
+*.out
+coverage.txt
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Documentation
+*.md
+LICENSE
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+SECURITY.md
+assets/
+
+# Logs and data
+logs/
+*.log
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Docker files
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# builder Stage
+FROM golang:1.21-alpine AS builder
+RUN apk add --no-cache git ca-certificates
+WORKDIR /app
+COPY go.mod go.sum* ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o twitch-miner .
+
+# runtime Stage
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates tzdata
+WORKDIR /app
+COPY --from=builder /app/twitch-miner .
+RUN mkdir -p /app/cookies /app/logs
+VOLUME ["/app/cookies", "/app/logs"]
+ENV CONFIG_PATH=/app/config.json
+CMD ["./twitch-miner"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,44 +7,74 @@ services:
     container_name: twitch-miner-account1
     restart: unless-stopped
     volumes:
-      - ./config.json:/app/config.json:ro
+      - ./configs/account1/config.json:/app/config.json:ro
       - ./cookies/account1:/app/cookies
       - ./logs/account1:/app/logs
     environment:
       - TZ=Europe/Berlin
-      - CONFIG_PATH=/app/config.json
+      - TCPM_CONFIG=/app/config.json
     networks:
       - twitch-miner-network
 
   # Second Instance - Account 2
-  # miner-account2:
-  #   build: .
-  #   container_name: twitch-miner-account2
-  #   restart: unless-stopped
-  #   volumes:
-  #     - ./config.json:/app/config.json:ro
-  #     - ./cookies/account2:/app/cookies
-  #     - ./logs/account2:/app/logs
-  #   environment:
-  #     - TZ=Europe/Berlin
-  #     - CONFIG_PATH=/app/config.json
-  #   networks:
-  #     - twitch-miner-network
+  miner-account2:
+    build: .
+    container_name: twitch-miner-account2
+    restart: unless-stopped
+    volumes:
+      - ./configs/account2/config.json:/app/config.json:ro
+      - ./cookies/account2:/app/cookies
+      - ./logs/account2:/app/logs
+    environment:
+      - TZ=Europe/Berlin
+      - TCPM_CONFIG=/app/config.json
+    networks:
+      - twitch-miner-network
 
-  # Third Instance - Account 3 (optional, commented out)
-  # miner-account3:
-  #   build: .
-  #   container_name: twitch-miner-account3
-  #   restart: unless-stopped
-  #   volumes:
-  #     - ./config.json:/app/config.json:ro
-  #     - ./cookies/account3:/app/cookies
-  #     - ./logs/account3:/app/logs
-  #   environment:
-  #     - TZ=Europe/Berlin
-  #     - CONFIG_PATH=/app/config.json
-  #   networks:
-  #     - twitch-miner-network
+  # Third Instance - Account 3
+  miner-account3:
+    build: .
+    container_name: twitch-miner-account3
+    restart: unless-stopped
+    volumes:
+      - ./configs/account3/config.json:/app/config.json:ro
+      - ./cookies/account3:/app/cookies
+      - ./logs/account3:/app/logs
+    environment:
+      - TZ=Europe/Berlin
+      - TCPM_CONFIG=/app/config.json
+    networks:
+      - twitch-miner-network
+
+  # Fourth Instance - Account 4
+  miner-account4:
+    build: .
+    container_name: twitch-miner-account4
+    restart: unless-stopped
+    volumes:
+      - ./configs/account4/config.json:/app/config.json:ro
+      - ./cookies/account4:/app/cookies
+      - ./logs/account4:/app/logs
+    environment:
+      - TZ=Europe/Berlin
+      - TCPM_CONFIG=/app/config.json
+    networks:
+      - twitch-miner-network
+
+  # Fifth Instance - Account 5
+  miner-account5:
+    build: .
+    container_name: twitch-miner-account5
+    restart: unless-stopped
+    volumes:
+      - ./configs/account5/config.json:/app/config.json:ro
+      - ./cookies/account5:/app/cookies
+      - ./logs/account5:/app/logs
+    environment:
+      - TZ=Europe/Berlin
+      - TCPM_CONFIG=/app/config.json
+    networks:
+      - twitch-miner-network
 
 networks:
   twitch-miner-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+
+services:
+  # First Instance - Account 1
+  miner-account1:
+    build: .
+    container_name: twitch-miner-account1
+    restart: unless-stopped
+    volumes:
+      - ./config.json:/app/config.json:ro
+      - ./cookies/account1:/app/cookies
+      - ./logs/account1:/app/logs
+    environment:
+      - TZ=Europe/Berlin
+      - CONFIG_PATH=/app/config.json
+    networks:
+      - twitch-miner-network
+
+  # Second Instance - Account 2
+  # miner-account2:
+  #   build: .
+  #   container_name: twitch-miner-account2
+  #   restart: unless-stopped
+  #   volumes:
+  #     - ./config.json:/app/config.json:ro
+  #     - ./cookies/account2:/app/cookies
+  #     - ./logs/account2:/app/logs
+  #   environment:
+  #     - TZ=Europe/Berlin
+  #     - CONFIG_PATH=/app/config.json
+  #   networks:
+  #     - twitch-miner-network
+
+  # Third Instance - Account 3 (optional, commented out)
+  # miner-account3:
+  #   build: .
+  #   container_name: twitch-miner-account3
+  #   restart: unless-stopped
+  #   volumes:
+  #     - ./config.json:/app/config.json:ro
+  #     - ./cookies/account3:/app/cookies
+  #     - ./logs/account3:/app/logs
+  #   environment:
+  #     - TZ=Europe/Berlin
+  #     - CONFIG_PATH=/app/config.json
+  #   networks:
+  #     - twitch-miner-network
+
+networks:
+  twitch-miner-network:
+    driver: bridge

--- a/docker-init.ps1
+++ b/docker-init.ps1
@@ -1,0 +1,36 @@
+# Docker initialization script creates necessary directories
+
+Write-Host "Initializing Docker directories..." -ForegroundColor Cyan
+
+# Create directories for 5 accounts
+$accounts = 1..5 | ForEach-Object { "account$_" }
+
+foreach ($account in $accounts) {
+    $cookieDir = "cookies\$account"
+    $logDir = "logs\$account"
+    
+    if (!(Test-Path $cookieDir)) {
+        New-Item -ItemType Directory -Path $cookieDir -Force | Out-Null
+        Write-Host "✓ Created: $cookieDir" -ForegroundColor Green
+    } else {
+        Write-Host "✓ Exists: $cookieDir" -ForegroundColor Gray
+    }
+    
+    if (!(Test-Path $logDir)) {
+        New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+        Write-Host "✓ Created: $logDir" -ForegroundColor Green
+    } else {
+        Write-Host "✓ Exists: $logDir" -ForegroundColor Gray
+    }
+}
+
+# Check if config.json exists
+if (!(Test-Path "config.json")) {
+    Write-Host "⚠ Warning: config.json not found!" -ForegroundColor Yellow
+    Write-Host "  Please create a config.json in the root directory." -ForegroundColor Yellow
+} else {
+    Write-Host "✓ config.json found" -ForegroundColor Green
+}
+
+Write-Host "`nInitialization complete!" -ForegroundColor Green
+Write-Host "You can now run 'docker-compose up -d'." -ForegroundColor Cyan


### PR DESCRIPTION
Introduce Docker tooling to run the Go app in containers. Adds a .dockerignore, a multi-stage Dockerfile (golang:1.21-alpine builder -> alpine runtime) that builds a static twitch-miner binary, and a docker-compose.yml with an example service for account1 (additional instances commented out) using bind mounts for config, cookies and logs and a dedicated bridge network. Also add docker-init.ps1 to create cookies/ and logs/ directories for up to 5 accounts and to warn if config.json is missing. This makes it easier to build, run and manage multiple containerized instances of the application at the same time.