### PR TITLE
Fix MinuteWatched still counting after a stream gets pre-empted in priority

### DIFF
--- a/TwitchChannelPointsMiner/classes/entities/stream.go
+++ b/TwitchChannelPointsMiner/classes/entities/stream.go
@@ -70,7 +70,15 @@ func (s *Stream) UpdateRequired() bool {
 
 func (s *Stream) UpdateMinuteWatched() {
 	if !s.lastMinuteUpdate.IsZero() {
-		s.MinuteWatched += time.Since(s.lastMinuteUpdate).Minutes()
+		duration := time.Since(s.lastMinuteUpdate).Minutes()
+		// if it's been more than 2 minutes since last minute-watched update,
+		// stream probably was not being continuously watched, so reset to 0
+		// (likely got pre-empted by something higher priority)
+		if duration > 2.0 {
+			s.MinuteWatched = 0
+		} else {
+			s.MinuteWatched += duration
+		}
 	}
 	s.lastMinuteUpdate = time.Now()
 }


### PR DESCRIPTION
Here's a log example of this happening:
```
[INFO] 18:53 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=04m 43s)
SLOT 2: Streamer4 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=12, streakRemaining=07m 00s)
[INFO] 18:53 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=04m 21s)
SLOT 2: Streamer4 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=12, streakRemaining=07m 00s)
[INFO] 18:54 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=03m 59s)
SLOT 2: Streamer4 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=12, streakRemaining=06m 38s)
[INFO] 18:54 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=03m 36s)
SLOT 2: Streamer4 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=12, streakRemaining=06m 14s)
[INFO] 18:54 04/04/26: 🥳 Streamer2 (70.1k points) is Online!
[INFO] 18:55 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=03m 09s)
SLOT 2: Streamer4 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=12, streakRemaining=05m 47s)
[INFO] 18:55 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=02m 46s)
SLOT 2: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=07m 00s)
[INFO] 18:55 04/04/26: 🚀 +10 → Streamer1 (56.4k points) - Reason: WATCH | Game: Just Chatting
[INFO] 18:55 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=02m 25s)
SLOT 2: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=07m 00s)
[INFO] 18:56 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=02m 03s)
SLOT 2: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=06m 39s)
[INFO] 18:56 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=01m 41s)
SLOT 2: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=06m 16s)
[INFO] 18:56 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=01m 18s)
SLOT 2: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=05m 53s)
[INFO] 18:57 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=51s)
SLOT 2: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=05m 26s)
[INFO] 18:57 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=29s)
SLOT 2: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=05m 04s)
[INFO] 18:58 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer1 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=6, streakRemaining=07s)
SLOT 2: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=04m 42s)
[INFO] 18:58 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=04m 21s)
SLOT 2: Streamer3 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=8, streakRemaining=07m 00s)
[INFO] 18:58 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=04m 09s)
SLOT 2: Streamer3 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=8, streakRemaining=07m 00s)
[INFO] 18:59 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=03m 45s)
SLOT 2: Streamer3 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=8, streakRemaining=06m 37s)
[INFO] 18:59 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=03m 19s)
SLOT 2: Streamer3 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=8, streakRemaining=06m 10s)
[INFO] 18:59 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer2 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=7, streakRemaining=02m 56s)
SLOT 2: Streamer3 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=8, streakRemaining=05m 48s)
[INFO] 19:00 04/04/26: 🚀 +10 → Streamer2 (70.11k points) - Reason: WATCH | Game: Chess
[INFO] 19:00 04/04/26: 🚀 +450 → Streamer2 (70.56k points) - Reason: WATCH_STREAK
[INFO] 19:00 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer3 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=8, streakRemaining=05m 25s)
SLOT 2: Streamer4 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=13, streakRemaining=05m 25s)
[INFO] 19:00 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer3 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=8, streakRemaining=05m 14s)
SLOT 2: Streamer4 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=13, streakRemaining=06s)
[INFO] 19:01 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer3 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=8, streakRemaining=04m 52s)
SLOT 2: Streamer5 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=14, streakRemaining=07m 00s)
[INFO] 19:01 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer3 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=8, streakRemaining=04m 28s)
SLOT 2: Streamer5 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=14, streakRemaining=07m 00s)
[INFO] 19:01 04/04/26: WATCH queue (≈10s between streamers):
SLOT 1: Streamer3 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=8, streakRemaining=04m 02s)
SLOT 2: Streamer5 (reason=STREAK, streak=true, priorityGame=false, rank=1, pos=14, streakRemaining=06m 33s)
```

We're initially watching streamers 1 and 4, but then Streamer2 comes online at 18:54 and Streamer4 gets pre-empted with less than 2 minutes of watch time accrued. After watching Streamer2 for long enough to get a watch streak, we re-start watching Streamer4 again at 19:00 but you can see the `streakRemaining` time drop from `05m25s` to `06s` in a single step and that stream falls off the queue, missing the streak.

The bug is this `time.Since(s.lastMinuteUpdate)` calculation assumes the same stream has been continuously watched, which won't always be the case if higher-priority streams have come online during a watch attempt. This proposed fix is a bit of a bandaid, and not ideal for overall throughput. A better fix might be to only recalculate the queue priority list when one (or both) watch slot finishes and we need to pick the next stream to watch, instead of constantly recalculating it every 20 seconds.