### PR TITLE
Include streak length in logOnline and logOffline

### DIFF
--- a/TwitchChannelPointsMiner/classes/twitch.go
+++ b/TwitchChannelPointsMiner/classes/twitch.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -480,6 +481,21 @@ func extractWatchStreakAchievementAt(resp *gqlRewardListResponse) time.Time {
 	return parseRFC3339Timestamp(milestone.WatchStreakMilestone.AchievementTimestamp)
 }
 
+func extractWatchStreakLength(resp *gqlRewardListResponse) int {
+	if resp == nil || resp.Data.Channel == nil || resp.Data.Channel.Self == nil {
+		return -1
+	}
+	milestone := resp.Data.Channel.Self.WatchStreakMilestone
+	if milestone == nil || milestone.WatchStreakMilestone == nil {
+		return -1
+	}
+	out, err := strconv.Atoi(milestone.WatchStreakMilestone.Value)
+	if err != nil {
+		return -1
+	}
+	return out
+}
+
 func (t *Twitch) fallbackStreamCreatedAt(channelID string) time.Time {
 	if channelID == "" {
 		return time.Time{}
@@ -515,6 +531,23 @@ func (t *Twitch) rewardListAchievementAt(channelID string) time.Time {
 		return time.Time{}
 	}
 	return extractWatchStreakAchievementAt(&resp)
+}
+
+func (t *Twitch) RewardListStreakLength(channelID string) int {
+	if channelID == "" {
+		return -1
+	}
+	op := constants.ClonePersistedOperation(constants.GQLOperations.RewardList)
+	if op.Variables == nil {
+		op.Variables = map[string]interface{}{}
+	}
+	op.Variables["channelID"] = channelID
+	var resp gqlRewardListResponse
+	if err := t.PostGQLDecode(op, &resp); err != nil {
+		t.debugf("RewardList lookup failed for channel %s: %v", channelID, err)
+		return -1
+	}
+	return extractWatchStreakLength(&resp)
 }
 
 func (t *Twitch) streamInfoOverlay(username, channelID string) (*streamInfoResult, error) {

--- a/TwitchChannelPointsMiner/classes/twitch_gql_types.go
+++ b/TwitchChannelPointsMiner/classes/twitch_gql_types.go
@@ -70,6 +70,7 @@ type gqlRewardListResponse struct {
 			Self *struct {
 				WatchStreakMilestone *struct {
 					WatchStreakMilestone *struct {
+						Value                string `json:"value"`
 						AchievementTimestamp string `json:"achievementTimestamp"`
 					} `json:"watchStreakMilestone"`
 				} `json:"watchStreakMilestone"`

--- a/TwitchChannelPointsMiner/miner.go
+++ b/TwitchChannelPointsMiner/miner.go
@@ -1136,13 +1136,15 @@ func (m *Miner) logOnline(streamer *entities.Streamer) {
 	if suffix := m.gameSuffix(streamer); suffix != "" {
 		gameSuffix = fmt.Sprintf(" | %s %s", fmt.Sprintf("%sPlaying:%s", colorGameLabel, colorReset), suffix)
 	}
-	m.logger.EmojiEventf(":partying_face:", constants.EventStreamerOnline, "%s (%s%s%s points) is %sOnline%s!%s", name, colorCyan, points, colorReset, colorGreen, colorReset, gameSuffix)
+	streaklengthSuffix := fmt.Sprintf(" | streak length %d", m.twitch.RewardListStreakLength(streamer.ChannelID))
+	m.logger.EmojiEventf(":partying_face:", constants.EventStreamerOnline, "%s (%s%s%s points) is %sOnline%s!%s%s", name, colorCyan, points, colorReset, colorGreen, colorReset, streaklengthSuffix, gameSuffix)
 }
 
 func (m *Miner) logOffline(streamer *entities.Streamer) {
 	name := m.styledStreamerName(streamer)
 	points := m.formattedStreamerPoints(streamer)
-	m.logger.EmojiEventf(":sleeping:", constants.EventStreamerOffline, "%s (%s%s%s points) is %sOffline%s!", name, colorCyan, points, colorReset, colorRed, colorReset)
+	streaklengthSuffix := fmt.Sprintf(" | streak length %d", m.twitch.RewardListStreakLength(streamer.ChannelID))
+	m.logger.EmojiEventf(":sleeping:", constants.EventStreamerOffline, "%s (%s%s%s points) is %sOffline%s!%s", name, colorCyan, points, colorReset, colorRed, colorReset, streaklengthSuffix)
 }
 
 func (m *Miner) handleGameChange(streamer *entities.Streamer, previous, current string) {


### PR DESCRIPTION
ref https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/issues/775#issuecomment-3670019035, the RewardList API also includes streak length

Up to you whether you'd like this info in the logs or not, but I can imagine using this to implement an option for prioritizing streams based on streak length, for example.