### PR TITLE
Add some more placeholder gql info

### DIFF
--- a/TwitchChannelPointsMiner/classes/twitch.go
+++ b/TwitchChannelPointsMiner/classes/twitch.go
@@ -481,6 +481,17 @@ func extractWatchStreakAchievementAt(resp *gqlRewardListResponse) time.Time {
 	return parseRFC3339Timestamp(milestone.WatchStreakMilestone.AchievementTimestamp)
 }
 
+func extractWatchStreakExpiresAt(resp *gqlRewardListResponse) time.Time {
+	if resp == nil || resp.Data.Channel == nil || resp.Data.Channel.Self == nil {
+		return time.Time{}
+	}
+	milestone := resp.Data.Channel.Self.WatchStreakMilestone
+	if milestone == nil {
+		return time.Time{}
+	}
+	return parseRFC3339Timestamp(milestone.ExpiresAt)
+}
+
 func extractWatchStreakLength(resp *gqlRewardListResponse) int {
 	if resp == nil || resp.Data.Channel == nil || resp.Data.Channel.Self == nil {
 		return -1

--- a/TwitchChannelPointsMiner/classes/twitch_gql_types.go
+++ b/TwitchChannelPointsMiner/classes/twitch_gql_types.go
@@ -73,6 +73,7 @@ type gqlRewardListResponse struct {
 						Value                string `json:"value"`
 						AchievementTimestamp string `json:"achievementTimestamp"`
 					} `json:"watchStreakMilestone"`
+					ExpiresAt string `json:"expiresAt"`
 				} `json:"watchStreakMilestone"`
 			} `json:"self"`
 		} `json:"channel"`

--- a/TwitchChannelPointsMiner/classes/twitch_gql_types.go
+++ b/TwitchChannelPointsMiner/classes/twitch_gql_types.go
@@ -20,7 +20,8 @@ type gqlChannelPointsContextResponse struct {
 					} `json:"communityPoints"`
 				} `json:"self"`
 				CommunityPointsSettings struct {
-					Goals json.RawMessage `json:"goals"`
+					Goals     json.RawMessage `json:"goals"`
+					IsEnabled bool            `json:"isEnabled"`
 				} `json:"communityPointsSettings"`
 			} `json:"channel"`
 		} `json:"community"`


### PR DESCRIPTION
Initial scaffolding for some future enhancements I have in mind: streak expiration time, and `IsEnabled` flag for `CommunityPointsSettings`

A small enhancement would be to skip channels when our points balance is zero and the settings tell us channel points are completely disabled. A bigger more complicated feature would be to check (and schedule a re-check after 30 minutes offline) for expiring streaks and seeing if auto-saving those by watching clips or vods might be possible. I've observed that manual clip or vod streak saving can be done without counting towards the 2 concurrent stream watch limit, so maybe we could eventually add a third (or more) worker task for it.