### PR TITLE
also lock activeStreakWatches reads

### DIFF
--- a/TwitchChannelPointsMiner/miner.go
+++ b/TwitchChannelPointsMiner/miner.go
@@ -827,6 +827,7 @@ func (m *Miner) pickStreamersToWatch(streamers []*entities.Streamer) []*entities
 		}
 	}
 
+	m.activeStreakMu.Lock()
 	if len(m.activeStreakWatches) > 0 {
 		activeStreaks := make([]candidate, 0, len(m.activeStreakWatches))
 		for _, c := range candidates {
@@ -840,9 +841,7 @@ func (m *Miner) pickStreamersToWatch(streamers []*entities.Streamer) []*entities
 				continue
 			}
 			if !m.shouldKeepActiveStreak(s, now) || !activeStreakWatchMatches(s, watch) {
-				m.activeStreakMu.Lock()
 				delete(m.activeStreakWatches, key)
-				m.activeStreakMu.Unlock()
 				continue
 			}
 			activeStreaks = append(activeStreaks, c)
@@ -854,6 +853,7 @@ func (m *Miner) pickStreamersToWatch(streamers []*entities.Streamer) []*entities
 			}
 		}
 	}
+	m.activeStreakMu.Unlock()
 
 	skipEarlyStreak := len(m.gamePriority) > 0 && !hasPriorityGameStreak
 
@@ -1084,11 +1084,11 @@ func (m *Miner) syncActiveStreakWatch(streamer *entities.Streamer, now time.Time
 		return
 	}
 	if !m.shouldKeepActiveStreak(streamer, now) {
+		m.activeStreakMu.Lock()
 		if m.activeStreakWatches != nil {
-			m.activeStreakMu.Lock()
 			delete(m.activeStreakWatches, key)
-			m.activeStreakMu.Unlock()
 		}
+		m.activeStreakMu.Unlock()
 		return
 	}
 	m.activeStreakMu.Lock()


### PR DESCRIPTION
This was much rarer than the error that #30 fixed, but after roughly 8 hours of runtime I hit
```
fatal error: concurrent map read and map write

goroutine 4877 [running]:
internal/runtime/maps.fatal({0x7fb238?, 0x60?})
        /home/tkelman/go/src/runtime/panic.go:1181 +0x18
TwitchChannelPointsMiner/TwitchChannelPointsMiner.(*Miner).pickStreamersToWatch(0x271f9190e780, {0x271f91b5c008, 0x47b, 0x47c})
        /home/tkelman/github/Twitch-Channel-Points-Miner/TwitchChannelPointsMiner/miner.go:838 +0xaaf
TwitchChannelPointsMiner/TwitchChannelPointsMiner.(*Miner).minuteWatcher(0x271f9190e780, {0x271f91b5c008, 0x47b, 0x47c}, 0x271f9181fb20)
        /home/tkelman/github/Twitch-Channel-Points-Miner/TwitchChannelPointsMiner/miner.go:462 +0x8d
created by TwitchChannelPointsMiner/TwitchChannelPointsMiner.(*Miner).run in goroutine 1
        /home/tkelman/github/Twitch-Channel-Points-Miner/TwitchChannelPointsMiner/miner.go:390 +0x12f0
exit status 2
```

Having locks on the reads too feels like a not ideal fix, there will probably be more contention on this? I'll run it like this and see if I notice any issues.