### PR TITLE
Upstreaming a few minor parameter tweaks from my branch

### DIFF
--- a/TwitchChannelPointsMiner/miner.go
+++ b/TwitchChannelPointsMiner/miner.go
@@ -1950,7 +1950,7 @@ func (m *Miner) updateHistory(streamer *entities.Streamer, reason string, amount
 	}
 	if reason == "WATCH" {
 		streamer.Stream.WatchCount++
-		if streamer.Stream.WatchStreakMissing && streamer.Stream.WatchCount >= 2 {
+		if streamer.Stream.WatchStreakMissing && streamer.Stream.WatchCount >= 1 {
 			markActualStreakCompleted(streamer)
 		}
 		m.syncActiveStreakWatch(streamer, time.Now())

--- a/TwitchChannelPointsMiner/miner.go
+++ b/TwitchChannelPointsMiner/miner.go
@@ -951,7 +951,7 @@ func (m *Miner) pickStreamersToWatch(streamers []*entities.Streamer) []*entities
 		if streamerWatchBackedOff(s, now) {
 			continue
 		}
-		if !s.OnlineAt.IsZero() && now.Sub(s.OnlineAt) < 30*time.Second {
+		if !s.OnlineAt.IsZero() && now.Sub(s.OnlineAt) < 0*time.Second {
 			continue
 		}
 		m.refreshStreamForPreference(s)

--- a/TwitchChannelPointsMiner/miner.go
+++ b/TwitchChannelPointsMiner/miner.go
@@ -30,8 +30,8 @@ const (
 )
 
 const (
-	streakPriorityMinutesBase     = 7.0
-	streakPriorityMinutesExtended = 20.0
+	streakPriorityMinutesBase     = 15.0
+	streakPriorityMinutesExtended = 15.0
 	resolvedStreakCarryoverWindow = 30 * time.Minute
 	falseOfflineStreamStartGrace  = 2 * time.Minute
 )


### PR DESCRIPTION
Up to you whether you want to incorporate any or all of these officially.

1. Require a single WATCH event instead of 2. I haven't seen a case where a WATCH_STREAK event doesn't come with the first WATCH event, except for the first stream going from streak length 0 to 1. And in that condition, additional WATCH events won't get the WATCH_STREAK points until the next separate stream. I have noticed a single instance of getting a WATCH_STREAK event without an accompanying WATCH event - the miner handled this fine, but some of my log post-processing scripts did need to be made more robust for it. And one time the miner did accrue a WATCH & WATCH_STREAK pair but the twitch backend didn't increment the streak length so it counted as a missed streak, I don't know what went wrong in that situation but consider it a fluke.
2. Set the streak watch time counters to 15 minutes. I see a lot of cases that require more than 7 minutes, but very few that require all of 15 minutes. Here's some data from a 3.5 day long session, how many hits in the log file for streakRemaining=x:

| x | hits |
| --- | ---- |
| 15m | 3723 |
| 14m | 3349 |
| 13m | 3789 |
| 12m | 3933 |
| 11m | 3017 |
| 10m | 552 |
| 09m | 496 |
| 08m | 519 |
| 07m | 507 |
| 06m | 330 |
| 05m | 77 |
| 04m | 35 |
| 03m | 33 |
| 02m | 30 |
| 01m | 16 |
| \d\ds | 13 |

all but one instance that got down to seconds remaining were channels that had points disabled, that one instance got its watch streak with 58 seconds left

3. Disable waiting 30 seconds after a stream comes online before allowing watch time to start. Can you recall what this delay was added for?