### PR TITLE
add a mutex for streamer.History

### DIFF
--- a/TwitchChannelPointsMiner/classes/entities/types.go
+++ b/TwitchChannelPointsMiner/classes/entities/types.go
@@ -1,6 +1,9 @@
 package entities
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 type FollowersOrder string
 
@@ -114,6 +117,7 @@ type Streamer struct {
 	ActiveMultipliers            []ActiveMultiplier `json:"-"`
 	LastRaidID                   string             `json:"-"`
 	History                      map[string]*HistoryEntry
+	HistoryMu                    sync.Mutex
 	CommunityGoals               map[string]*CommunityGoal `json:"-"`
 }
 

--- a/TwitchChannelPointsMiner/miner.go
+++ b/TwitchChannelPointsMiner/miner.go
@@ -1612,6 +1612,7 @@ func (m *Miner) updateHistory(streamer *entities.Streamer, reason string, amount
 	if reason == "" {
 		return
 	}
+	streamer.HistoryMu.Lock()
 	if streamer.History == nil {
 		streamer.History = make(map[string]*entities.HistoryEntry)
 	}
@@ -1622,6 +1623,7 @@ func (m *Miner) updateHistory(streamer *entities.Streamer, reason string, amount
 	}
 	entry.Count++
 	entry.Amount += amount
+	streamer.HistoryMu.Unlock()
 	if streamer.Stream == nil {
 		return
 	}


### PR DESCRIPTION
very rare but I hit a "fatal error: concurrent map writes" for streamer.History in updateHistory when two streamers got streak points simultaneously

```
fatal error: concurrent map writes

goroutine 15318 [running]:
internal/runtime/maps.fatal({0x7f4f47?, 0x1c30b1c6bc78?})
        /home/tkelman/go/src/runtime/panic.go:1181 +0x18
TwitchChannelPointsMiner/TwitchChannelPointsMiner.(*Miner).updateHistory(0x1c30b175d0e0, 0x1c30b1a03080, {0x1c30b27a11d0, 0xc}, 0x1c2)
        /home/tkelman/github/Twitch-Channel-Points-Miner/TwitchChannelPointsMiner/miner.go:1621 +0xdf
TwitchChannelPointsMiner/TwitchChannelPointsMiner.(*Miner).handlePubSubGain(0x1c30b175d0e0, 0x1c30b1a03080, 0x1c2, {0x1c30b27a11d0, 0xc}, 0x1c30b2603c50?)
        /home/tkelman/github/Twitch-Channel-Points-Miner/TwitchChannelPointsMiner/miner.go:1605 +0xe8
TwitchChannelPointsMiner/TwitchChannelPointsMiner/classes.(*PubSubClient).processPointsEarned(0x1c30b17f9110, 0x1c30b1a60ea0, {0x1c30b27a11b8, 0x8})
        /home/tkelman/github/Twitch-Channel-Points-Miner/TwitchChannelPointsMiner/classes/pubsub.go:564 +0x20d
TwitchChannelPointsMiner/TwitchChannelPointsMiner/classes.(*PubSubClient).handleTopicMessage(0x1c30b17f9110, 0x1c4?)
        /home/tkelman/github/Twitch-Channel-Points-Miner/TwitchChannelPointsMiner/classes/pubsub.go:420 +0x3e5
TwitchChannelPointsMiner/TwitchChannelPointsMiner/classes.(*PubSubClient).handleMessage(0x1c30b17f9110, {0x1c30b34a3600, 0x1c4, 0x200}, 0x0)
        /home/tkelman/github/Twitch-Channel-Points-Miner/TwitchChannelPointsMiner/classes/pubsub.go:389 +0x105
TwitchChannelPointsMiner/TwitchChannelPointsMiner/classes.(*PubSubClient).connectAndListen.func1()
        /home/tkelman/github/Twitch-Channel-Points-Miner/TwitchChannelPointsMiner/classes/pubsub.go:182 +0x10c
created by TwitchChannelPointsMiner/TwitchChannelPointsMiner/classes.(*PubSubClient).connectAndListen in goroutine 6664
        /home/tkelman/github/Twitch-Channel-Points-Miner/TwitchChannelPointsMiner/classes/pubsub.go:172 +0x297
exit status 2
```

~~I do want to accumulate a bit of run time with this addition to make sure it doesn't do anything unexpected.~~ edit: a couple days running with it and no obvious stalls or runtime panics. It did take like 2.5 months of almost continuous running before first hitting these simultaneous writes though.