### PR TITLE
Include expiresAt, createdAt and achievementAt in logOnline

### DIFF
--- a/TwitchChannelPointsMiner/classes/twitch.go
+++ b/TwitchChannelPointsMiner/classes/twitch.go
@@ -604,9 +604,9 @@ func (t *Twitch) rewardListAchievementAt(channelID string) time.Time {
 	return extractWatchStreakAchievementAt(&resp)
 }
 
-func (t *Twitch) RewardListStreakLength(channelID string) int {
+func (t *Twitch) LogExtraInfo(channelID string, online bool) string {
 	if channelID == "" {
-		return -1
+		return ""
 	}
 	op := constants.ClonePersistedOperation(constants.GQLOperations.RewardList)
 	if op.Variables == nil {
@@ -616,9 +616,21 @@ func (t *Twitch) RewardListStreakLength(channelID string) int {
 	var resp gqlRewardListResponse
 	if err := t.PostGQLDecode(op, &resp); err != nil {
 		t.debugf("RewardList lookup failed for channel %s: %v", channelID, err)
-		return -1
+		return ""
 	}
-	return extractWatchStreakLength(&resp)
+	extrainfoSuffix := fmt.Sprintf(" | streak length %d", extractWatchStreakLength(&resp))
+	if expiresAt := extractWatchStreakExpiresAt(&resp); !expiresAt.IsZero() {
+		extrainfoSuffix += fmt.Sprintf(" | expires at %s", expiresAt.Local())
+	}
+	if online {
+		if createdAt := t.fallbackStreamCreatedAt(channelID); !createdAt.IsZero() {
+			extrainfoSuffix += fmt.Sprintf(" | started at %s", createdAt.Local())
+		}
+		if achievementAt := extractWatchStreakAchievementAt(&resp); !achievementAt.IsZero() {
+			extrainfoSuffix += fmt.Sprintf(" | streak achievement timestamp %s", achievementAt.Local())
+		}
+	}
+	return extrainfoSuffix
 }
 
 func (t *Twitch) streamInfoOverlay(username, channelID string) (*streamInfoResult, error) {

--- a/TwitchChannelPointsMiner/miner.go
+++ b/TwitchChannelPointsMiner/miner.go
@@ -1586,21 +1586,21 @@ func (m *Miner) logOnline(streamer *entities.Streamer) {
 	if suffix := m.gameSuffix(streamer); suffix != "" {
 		gameSuffix = fmt.Sprintf(" | %s %s", fmt.Sprintf("%sPlaying:%s", colorGameLabel, colorReset), suffix)
 	}
-	streaklengthSuffix := ""
+	extrainfoSuffix := ""
 	if m.twitch != nil && streamer != nil && streamer.ChannelID != "" {
-		streaklengthSuffix = fmt.Sprintf(" | streak length %d", m.twitch.RewardListStreakLength(streamer.ChannelID))
+		extrainfoSuffix = m.twitch.LogExtraInfo(streamer.ChannelID, true)
 	}
-	m.logger.EmojiEventf(":partying_face:", constants.EventStreamerOnline, "%s (%s%s%s points) is %sOnline%s!%s%s", name, colorCyan, points, colorReset, colorGreen, colorReset, streaklengthSuffix, gameSuffix)
+	m.logger.EmojiEventf(":partying_face:", constants.EventStreamerOnline, "%s (%s%s%s points) is %sOnline%s!%s%s", name, colorCyan, points, colorReset, colorGreen, colorReset, gameSuffix, extrainfoSuffix)
 }
 
 func (m *Miner) logOffline(streamer *entities.Streamer) {
 	name := m.styledStreamerName(streamer)
 	points := m.formattedStreamerPoints(streamer)
-	streaklengthSuffix := ""
+	extrainfoSuffix := ""
 	if m.twitch != nil && streamer != nil && streamer.ChannelID != "" {
-		streaklengthSuffix = fmt.Sprintf(" | streak length %d", m.twitch.RewardListStreakLength(streamer.ChannelID))
+		extrainfoSuffix = m.twitch.LogExtraInfo(streamer.ChannelID, false)
 	}
-	m.logger.EmojiEventf(":sleeping:", constants.EventStreamerOffline, "%s (%s%s%s points) is %sOffline%s!%s", name, colorCyan, points, colorReset, colorRed, colorReset, streaklengthSuffix)
+	m.logger.EmojiEventf(":sleeping:", constants.EventStreamerOffline, "%s (%s%s%s points) is %sOffline%s!%s", name, colorCyan, points, colorReset, colorRed, colorReset, extrainfoSuffix)
 }
 
 func (m *Miner) handleGameChange(streamer *entities.Streamer, previous, current string) {


### PR DESCRIPTION
This is a commit I've had sitting in my wip branch for a while, it's independent of and unrelated to the tweaks in #37 - my log post-processing scripts have been making use of `createdAt` and `achievementAt` to confirm whether a streak is warm-started at the start of a miner session