### PR TITLE
Add an extra sleep if a small number of clips (and no vods) are found

### DIFF
--- a/TwitchChannelPointsMiner/classes/twitch.go
+++ b/TwitchChannelPointsMiner/classes/twitch.go
@@ -1425,6 +1425,8 @@ func (t *Twitch) RecoverStreak(streamer *entities.Streamer) (bool, error) {
 	}
 	length0 := extractWatchStreakLength(&resp0)
 
+	clipsfound := 0
+	vodsfound := 0
 	for _, filter := range []string{"LAST_DAY", "LAST_WEEK", "videos"} {
 		// check clips, last day first then last week (in case clips just over 24 hours old are from missed stream)
 		// then check vods
@@ -1476,6 +1478,7 @@ func (t *Twitch) RecoverStreak(streamer *entities.Streamer) (bool, error) {
 
 					if mode == "clips" {
 						// clip from a missed stream, eligible for saving streak, watch it
+						clipsfound += 1
 						url, _ := node["url"].(string)
 						clipid, _ := node["id"].(string)
 						slug, _ := node["slug"].(string)
@@ -1532,6 +1535,7 @@ func (t *Twitch) RecoverStreak(streamer *entities.Streamer) (bool, error) {
 						}
 					} else {
 						// vod from a missed stream, eligible for saving streak, watch it
+						vodsfound += 1
 						vodid, _ := node["id"].(string)
 						publishedAt, _ := node["publishedAt"].(string)
 						eventProps := map[string]interface{}{
@@ -1583,6 +1587,14 @@ func (t *Twitch) RecoverStreak(streamer *entities.Streamer) (bool, error) {
 				}
 				hasNext = false
 			}
+		}
+	}
+	if vodsfound == 0 {
+		// add an extra sleep to let streak expiration refresh here
+		if clipsfound == 1 {
+			time.Sleep(10 * time.Second)
+		} else if clipsfound > 1 {
+			time.Sleep(5 * time.Second)
 		}
 	}
 


### PR DESCRIPTION
can incorrectly hit the "no eligible clips or vods found" condition otherwise, even though the streak is successfully saved from the nonzero number of found clips - I mentioned this possibility here https://github.com/0x8fv/Twitch-Channel-Points-Miner/pull/46#issuecomment-5245032239 and finally saw it happen once in practice, so adding this extra small sleep to make it much less likely. If a vod is found then the sleeps in that 5-minute loop will definitely be enough to early exit after refreshing the streak RewardList expiresAt state from any successful clip watches that happen first. A little more commonly than 1 clip and no vods, I've also seen cases of watching 3 clips before the streak state refreshes as successfully saved, or watching 2 clips then starting to watch minute 0 of a vod before the state refreshes.