### PR TITLE
Try getting ChannelID from warmStartCache if GetChannelID fails

### DIFF
--- a/TwitchChannelPointsMiner/miner.go
+++ b/TwitchChannelPointsMiner/miner.go
@@ -510,8 +510,19 @@ func (m *Miner) run(streamers []string, useFollowers bool, order entities.Follow
 		}
 		id, err := m.twitch.GetChannelID(name)
 		if err != nil {
-			m.logger.Printf("skip %s: %v", m.rawStreamerName(name), err)
-			continue
+			// if channel id can't be gotten from twitch, try checking warm start cache
+			// in case streamer has changed names recently
+			id = ""
+			if m.warmStartCache != nil {
+				entry, ok := m.warmStartCache.get(name)
+				if ok {
+					id = strings.TrimSpace(entry.ChannelID)
+				}
+			}
+			if id == "" {
+				m.logger.Printf("skip %s: %v", m.rawStreamerName(name), err)
+				continue
+			}
 		}
 		s.ChannelID = id
 		prev := s.ChannelPoints


### PR DESCRIPTION
Can be useful for recently renamed or recently suspended channels - should fix https://github.com/0x8fv/Twitch-Channel-Points-Miner/issues/36#issuecomment-5340700748, the last remaining little issue there